### PR TITLE
Serve existing index.html files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,11 @@ go 1.21.0
 require (
 	github.com/alecthomas/kong v0.8.0
 	github.com/rs/cors v1.10.0
+	github.com/stretchr/testify v1.8.4
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,17 @@ github.com/alecthomas/kong v0.8.0 h1:ryDCzutfIqJPnNn0omnrgHLbAggDQM2VWHikE1xqK7s
 github.com/alecthomas/kong v0.8.0/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
 github.com/alecthomas/repr v0.1.0/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/cors v1.10.0 h1:62NOS1h+r8p1mW6FM0FSB0exioXLhd/sh15KpjWBZ+8=
 github.com/rs/cors v1.10.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main_test.go
+++ b/main_test.go
@@ -90,6 +90,27 @@ func TestServeSubIndex(t *testing.T) {
 	assert.Contains(t, string(body), title)
 }
 
+func TestServeSubIndexRedirect(t *testing.T) {
+	testDir := "root"
+	dirPath := "sub"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", fmt.Sprintf("/%s/index.html", dirPath), nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusMovedPermanently, response.StatusCode)
+	assert.Equal(t, "./", response.Header.Get("Location"))
+}
+
 func TestServeSubDirRedirect(t *testing.T) {
 	testDir := "root"
 	dirPath := "sub"
@@ -135,4 +156,108 @@ func TestServeSubFile(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, fmt.Sprintf("%s/%s\n", testDir, filePath), string(body))
+}
+
+func TestServeCustomIndex(t *testing.T) {
+	testDir := "root-with-index"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", "/", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "root-with-index/index.html\n", string(body))
+}
+
+func TestServeCustomSubIndex(t *testing.T) {
+	testDir := "root-with-index"
+	dirPath := "sub-with-index"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", fmt.Sprintf("/%s/", dirPath), nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "root-with-index/sub-with-index/index.html\n", string(body))
+}
+
+func TestServeExplicitIndexNotInPath(t *testing.T) {
+	testDir := "root-with-index"
+
+	s := &Serve{
+		Dir:           fmt.Sprintf("testdata/%s", testDir),
+		ExplicitIndex: true,
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", "/", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	title := fmt.Sprintf("<title>Index of %s</title>", testDir)
+	assert.Contains(t, string(body), title)
+}
+
+func TestServeExplicitIndexInPath(t *testing.T) {
+	testDir := "root-with-index"
+
+	s := &Serve{
+		Dir:           fmt.Sprintf("testdata/%s", testDir),
+		ExplicitIndex: true,
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", "/index.html", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "root-with-index/index.html\n", string(body))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeIndex(t *testing.T) {
+	testDir := "root"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", "/", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	title := fmt.Sprintf("<title>Index of %s</title>", testDir)
+	assert.Contains(t, string(body), title)
+}
+
+func TestServeFile(t *testing.T) {
+	testDir := "root"
+	filePath := "file.txt"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", fmt.Sprintf("/%s", filePath), nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/plain; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("%s/%s\n", testDir, filePath), string(body))
+}
+
+func TestServeSubIndex(t *testing.T) {
+	testDir := "root"
+	dirPath := "sub"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", fmt.Sprintf("/%s/", dirPath), nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/html; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	title := fmt.Sprintf("<title>Index of %s/%s</title>", testDir, dirPath)
+	assert.Contains(t, string(body), title)
+}
+
+func TestServeSubDirRedirect(t *testing.T) {
+	testDir := "root"
+	dirPath := "sub"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", fmt.Sprintf("/%s", dirPath), nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusMovedPermanently, response.StatusCode)
+	assert.Equal(t, fmt.Sprintf("%s/", dirPath), response.Header.Get("Location"))
+}
+
+func TestServeSubFile(t *testing.T) {
+	testDir := "root"
+	filePath := "sub/file.txt"
+
+	s := &Serve{
+		Dir: fmt.Sprintf("testdata/%s", testDir),
+	}
+
+	handler := s.handler()
+
+	request := httptest.NewRequest("GET", fmt.Sprintf("/%s", filePath), nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, request)
+
+	response := recorder.Result()
+
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "text/plain; charset=utf-8", response.Header.Get("Content-Type"))
+
+	body, err := io.ReadAll(response.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("%s/%s\n", testDir, filePath), string(body))
+}

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,28 @@ Flags:
       --dot               Serve dot files (files prefixed with a '.').
       --explicit-index    Only serve index.html files if URL path includes it.
 ```
+
+The `serve <dir>` command can be used to browse files in a directory via HTTP.  For example, `serve .` starts a server for browsing the files in the current working directory.
+
+## `--port`
+
+By default, files are served on port 4000 (e.g. `http://localhost:4000`).  To have the server listen on a different port, pass a different value to the `--port` argument (e.g. `serve --port 9000 .`).
+
+## `--no-cors`
+
+By default, files are served with [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).  To turn off this behavior, use the `--no-cors` argument (e.g. `serve --no-cors .`).
+
+## `--dot`
+
+By default, files and directories starting with a `.` will not be listed or served.  To allow browsing `.`-prefixed files, use the `--dot` argument (e.g. `serve --dot .`).
+
+## `--explicit-index`
+
+By default, if a directory does not include an `index.html` file, a listing of files in the directory will be served.  If a directory does include an `index.html` file, that file will be served instead of the directory listing.
+
+You can use the `--explicit-index` argument to make it so an existing `index.html` file is only served if the request URL ends with `/index.html`.  When this argument is used, requests that end in `/` will be served with a directory listing, and requests that end in `/index.html` will be served with the contents of the `index.html` file (or a 404 if that file doesn't exist).
+
+| URL path                  | `serve .` (with defaults)         | `serve --expcit-index .`          |
+| ------------------------- | --------------------------------- | --------------------------------- |
+| `/path/to/dir/`           | existing `index.html` is served   | directory listing is served       |
+| `/path/to/dir/index.html` | redirect to `/path/to/dir/`       | existing `index.html` is served   |

--- a/readme.md
+++ b/readme.md
@@ -9,8 +9,9 @@ Arguments:
   <dir>    Serve files from this directory.
 
 Flags:
-  -h, --help         Show context-sensitive help.
-      --port=4000    Listen on this port.
-      --[no-]cors    Include CORS support (on by default).
-      --dot          Serve dot files (files prefixed with a '.')
+  -h, --help              Show context-sensitive help.
+      --port=4000         Listen on this port.
+      --[no-]cors         Include CORS support (on by default).
+      --dot               Serve dot files (files prefixed with a '.').
+      --explicit-index    Only serve index.html files if URL path includes it.
 ```

--- a/testdata/root-with-index/index.html
+++ b/testdata/root-with-index/index.html
@@ -1,0 +1,1 @@
+root-with-index/index.html

--- a/testdata/root-with-index/sub-with-index/index.html
+++ b/testdata/root-with-index/sub-with-index/index.html
@@ -1,0 +1,1 @@
+root-with-index/sub-with-index/index.html

--- a/testdata/root/file.txt
+++ b/testdata/root/file.txt
@@ -1,0 +1,1 @@
+root/file.txt

--- a/testdata/root/sub/file.txt
+++ b/testdata/root/sub/file.txt
@@ -1,0 +1,1 @@
+root/sub/file.txt


### PR DESCRIPTION
By default, existing `index.html` files will be served if they exist.  The `--explicit-index` flag can be used to make it so an existing `index.html` file is only served when the URL path ends with `/index.html` (as opposed to just `/`).
